### PR TITLE
Parametrize API routes in nginx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 FROM nginx:1.14.1
 
-# Get dependancies for node install
+# Get dependencies for node install
 RUN apt-get update \
- && apt-get install -y -q --no-install-recommends \
-    ca-certificates curl gnupg gnupg2 gnupg1 nano git bzip2 libfontconfig1-dev xz-utils \
-    wget \
- && apt-get clean \
- && rm -r /var/lib/apt/lists/*
+  && apt-get install -y -q --no-install-recommends \
+  ca-certificates curl gnupg gnupg2 gnupg1 nano git bzip2 libfontconfig1-dev xz-utils \
+  wget \
+  && apt-get clean \
+  && rm -r /var/lib/apt/lists/*
 
- WORKDIR /app
+WORKDIR /app
 
 # Install Node
 ENV NPM_CONFIG_LOGLEVEL info
@@ -16,21 +16,11 @@ ENV NODE_VERSION 8.15.0
 
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
 RUN apt-get install -y nodejs
-#
-RUN npm install
-RUN npm install && \
-npm install -g gulp && \
-npm install -g aurelia-cli
 
+RUN npm install
 
 COPY dist /app
-
 COPY nginx.conf /etc/nginx
-RUN cat /etc/nginx/nginx.conf
-RUN ls -l
-EXPOSE 80 9000
 COPY entrypoint.sh /app/entrypoint.sh
-RUN chmod 777 /app/entrypoint.sh
-CMD ["./app/entrypoint.sh"]
-# Install module dependencies
-CMD ["nginx", "-g", "daemon off;"]
+
+CMD ["/app/entrypoint.sh"]

--- a/build-and-run-docker.sh
+++ b/build-and-run-docker.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+docker build -t codehub-ui:latest .
+docker run --rm -d -p 8080:80 -e PROXY_PASS_URL=$PROXY_PASS_URL codehub-ui:latest

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 envsubst '${PROXY_PASS_URL}' < /etc/nginx/nginx.conf > /etc/nginx/nginx.conf
-cat /etc/nginx/nginx.conf
 nginx -g 'daemon off;'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,4 @@
 #!/bin/bash
-set -e
-
-# Add initialisation logic here
-
-# Run application
-exec "$@"
+envsubst '${PROXY_PASS_URL}' < /etc/nginx/nginx.conf > /etc/nginx/nginx.conf
+cat /etc/nginx/nginx.conf
+nginx -g 'daemon off;'

--- a/nginx.conf
+++ b/nginx.conf
@@ -42,7 +42,6 @@ http {
 
     server {
         listen       80;
-        listen       81;
         server_name  0.0.0.0;
 
         #charset koi8-r;
@@ -54,7 +53,7 @@ http {
            root /app;
         }
         location /api {
-               proxy_pass http://internal-dev-codehub-api-895777295.us-east-1.elb.amazonaws.com:3000/api;
+               proxy_pass ${PROXY_PASS_URL};
         }
 
 


### PR DESCRIPTION
### Description

This is a prerequisite to fully-automated infrastructure deployments with Terraform as well as automated promotion and deployment processes.

In essence this turns the API proxy_pass variable route into an environment variable that we can set at runtime rather than hardcoding it into the config.

### Changes

- Replace route in nginx.conf with environment variable
- Rewrite entry point script to allow env var replacement
- Dockerfile cleanup and best practices
- Added build-and-run-docker.sh for simple local one-liner testing